### PR TITLE
fix compilation error on with gcc 8 on debian buster

### DIFF
--- a/varnishkafka.c
+++ b/varnishkafka.c
@@ -44,6 +44,7 @@
 #include <syslog.h>
 #include <netdb.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 #include <vdef.h>


### PR DESCRIPTION
error was:

/usr/include/varnish/vapi/vsm.h:46:2: error: unknown type name ‘uintptr_t’
