### PR TITLE
Allocate only the needed size for the format structure array

### DIFF
--- a/varnishkafka.c
+++ b/varnishkafka.c
@@ -198,14 +198,9 @@ static int format_add (int fmtr, const char *var, ssize_t varlen,
                        const char *def, ssize_t deflen, int flags) {
     struct fmt *fmt;
 
-    if (fconf.fmt_cnt >= fconf.fmt_size) {
-        fconf.fmt_size = (fconf.fmt_size ? : 32) * 2;
-        fconf.fmt = realloc(fconf.fmt,
-                     fconf.fmt_size * sizeof(*fconf.fmt));
-    }
+    assert(fconf.fmt_cnt < fconf.fmt_size);
 
     fmt = &fconf.fmt[fconf.fmt_cnt];
-    memset(fmt, 0, sizeof(*fmt));
 
     fmt->id    = fmtr;
     fmt->idx   = fconf.fmt_cnt;
@@ -926,6 +921,14 @@ static int format_parse (const char *format_orig, char *errstr, size_t errstr_si
 
     /* Perform legacy replacements. */
     format = string_replace_arr(format_orig, replace);
+
+    s = format;
+    fconf.fmt_size = 1;
+    while ( *s != '\0' &&  (s = strchr(s+1, '%')) )
+		fconf.fmt_size++;
+    fconf.fmt_size *= 2;
+    fconf.fmt = calloc(fconf.fmt_size, sizeof(*fconf.fmt));
+
 
     /* Parse the format string */
     s = t = format;


### PR DESCRIPTION
  This commit is just https://github.com/dabelenda/varnishkafka/commit/4f6a909e476a4e635cb92ba3e77d91e47b4ac94d
  with fixed indentation.


Since we can know how many format structures are needed before
allocating the memory, we can allocate immediately the correct
size and zero the structure in one go.

This avoids using realloc which can invalidate existing pointers.

The worst case for format elements is:
  <string> (%<ncsa formatter><string>)*
so we can use 2 * (1 + number of '%' in string) to be sure we never have
less than necessary elements in the array. (Note that the ncsa formatter
can contain '%' so we will allocate more memory than necessary).

